### PR TITLE
style: remove login button text, use icon-only circular buttons

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -166,11 +166,10 @@ export default function TenantPage() {
                             <button
                                 id="open-auth-modal-btn"
                                 onClick={() => setShowAuthModal(true)}
-                                className="flex items-center gap-2 px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] text-farm-forest/60 hover:text-farm-forest transition-all duration-300 rounded-full hover:bg-farm-forest/5"
+                                className="text-farm-forest/60 hover:text-farm-forest p-2 rounded-full hover:bg-farm-forest/5 transition-all duration-300"
                                 title={t.common.login}
                             >
                                 <LogIn size={18} />
-                                <span className="hidden sm:inline">{t.common.login}</span>
                             </button>
                         )}
                     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,11 +92,10 @@ export default function RootPage() {
                         <button
                             id="open-auth-modal-btn"
                             onClick={() => setShowAuthModal(true)}
-                            className="flex items-center gap-2 px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] text-farm-forest/60 hover:text-farm-forest transition-all duration-300 rounded-full hover:bg-farm-forest/5"
+                            className="text-farm-forest/60 hover:text-farm-forest p-2 rounded-full hover:bg-farm-forest/5 transition-all duration-300"
                             title={t.common.login}
                         >
                             <LogIn size={18} />
-                            <span className="hidden sm:inline">{t.common.login}</span>
                         </button>
                     )}
                     <LanguageToggle />


### PR DESCRIPTION
This PR removes the explicit 'Anmelden' / 'Login' text labels on both the landing page and tenant store pages, replacing them with a clean, circular icon-only button style for the Login action. This streamlines the header navigation aesthetics.