### PR TITLE
style: unify header elements ordering and login/logout icon sizes

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -169,7 +169,7 @@ export default function TenantPage() {
                                 className="text-farm-forest/60 hover:text-farm-forest p-2 rounded-full hover:bg-farm-forest/5 transition-all duration-300"
                                 title={t.common.login}
                             >
-                                <LogIn size={18} />
+                                <LogIn size={20} />
                             </button>
                         )}
                     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,6 +67,7 @@ export default function RootPage() {
                     {t.common.brand_name}
                 </div>
                 <div className="flex items-center gap-4">
+                    <LanguageToggle />
                     {user ? (
                         <div className="flex items-center gap-2">
                             <Link 
@@ -95,10 +96,9 @@ export default function RootPage() {
                             className="text-farm-forest/60 hover:text-farm-forest p-2 rounded-full hover:bg-farm-forest/5 transition-all duration-300"
                             title={t.common.login}
                         >
-                            <LogIn size={18} />
+                            <LogIn size={20} />
                         </button>
                     )}
-                    <LanguageToggle />
                 </div>
             </nav>
 


### PR DESCRIPTION
This PR reorders header controls on the landing page to place the LanguageToggle first (matching the store page layout: LanguageChooser, Profile, LogIn/LogOut from left to right) and unifies LogIn/LogOut icon sizes to exactly 20px on both pages.