### PR TITLE
fix: allow all shop owners to access the workbench and avoid white page

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -177,7 +177,7 @@ export default function TenantPage() {
             </nav>
 
             <div className="animate-in fade-in zoom-in-95 duration-1000">
-                {view === 'shop' || !isOwner ? <Shop tenant={tenant} /> : <Admin />}
+                {view === 'shop' || !isOwner ? <Shop tenant={tenant} /> : <Admin isOwner={isOwner} />}
             </div>
 
             {showAuthModal && (

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -15,12 +15,12 @@ import { TrendingUp, Package, ShoppingCart, BookOpen, AlertCircle, Eye, EyeOff, 
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 
-export default function Admin() {
+export default function Admin({ isOwner = false }: { isOwner?: boolean }) {
     const { user } = useAuth();
     const { t, locale } = useLanguage();
     const { notify } = useNotify();
 
-    if (!user || (user.role !== 'farmer_admin' && user.role !== 'platform_admin' && user.role !== 'staff')) {
+    if (!user || (!isOwner && user.role !== 'farmer_admin' && user.role !== 'platform_admin' && user.role !== 'staff')) {
         return null;
     }
 


### PR DESCRIPTION
This PR fixes a bug where shop owners who do not have the explicit role of platform_admin/farmer_admin/staff (but are in the tenant owners table) are shown a blank white page when accessing the workbench. We now pass down the isOwner status to the Admin component as a prop and permit rendering if the user is an authorized owner.