### PR TITLE
style: display specific backend checkout errors and fix initial loyalty tier fallback

### DIFF
--- a/src/components/Shop.tsx
+++ b/src/components/Shop.tsx
@@ -124,9 +124,10 @@ export default function Shop({ tenant }: ShopProps) {
             setOrderSuccess(true);
             setIsBasketOpen(false);
             setTimeout(() => setOrderSuccess(false), 5000);
-        } catch (err) {
+        } catch (err: any) {
             console.error("Checkout failed", err);
-            notify(t.shop.checkout_failed, 'error');
+            const errMsg = err.response?.data?.error || t.shop.checkout_failed;
+            notify(errMsg, 'error');
         } finally {
             setIsCheckingOut(false);
         }

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -290,7 +290,7 @@ export default function UserProfile() {
                         <div className="space-y-6">
                             <div className="flex justify-between items-center text-sm">
                                 <span className="text-farm-cream/60">{t.profile.tier}</span>
-                                <span className="font-bold text-farm-gold uppercase tracking-widest">{loyalty?.tier || t.profile.harvest_elite}</span>
+                                <span className="font-bold text-farm-gold uppercase tracking-widest">{loyalty?.tier || 'Seedling'}</span>
                             </div>
                             {loyalty && parseFloat(loyalty.discount_percent) > 0 && (
                                 <div className="flex justify-between items-center text-sm">


### PR DESCRIPTION
This PR updates the checkout error notification to display the specific backend error message (e.g. reminding the user to set their address in their profile) instead of a generic checkout failed message. It also fixes the initial loading fallback of the user loyalty tier on the profile page to correctly default to Seedling instead of Harvest Elite.