### PR TITLE
style: fix loyalty status heading text color visibility inside dark background

### DIFF
--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -286,7 +286,7 @@ export default function UserProfile() {
                 <aside className="space-y-8">
                     <div className="p-8 rounded-3xl bg-farm-forest text-farm-cream border-none shadow-2xl relative overflow-hidden">
                         <div className="absolute -bottom-10 -right-10 w-40 h-40 bg-farm-gold/10 rounded-full blur-2xl" />
-                        <h3 className="text-2xl font-serif mb-6">{t.profile.loyalty_status}</h3>
+                        <h3 className="text-2xl font-serif mb-6 text-farm-cream">{t.profile.loyalty_status}</h3>
                         <div className="space-y-6">
                             <div className="flex justify-between items-center text-sm">
                                 <span className="text-farm-cream/60">{t.profile.tier}</span>


### PR DESCRIPTION
This PR explicitly sets the text color of the Loyalty Status heading to text-farm-cream inside the bg-farm-forest dark container. This overrides the global h3 dark green text style which was making the title invisible against the dark green background.