### PR TITLE
style: bulletproof loyalty status heading color using inline style and important class

### DIFF
--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -286,7 +286,7 @@ export default function UserProfile() {
                 <aside className="space-y-8">
                     <div className="p-8 rounded-3xl bg-farm-forest text-farm-cream border-none shadow-2xl relative overflow-hidden">
                         <div className="absolute -bottom-10 -right-10 w-40 h-40 bg-farm-gold/10 rounded-full blur-2xl" />
-                        <h3 className="text-2xl font-serif mb-6 text-farm-cream">{t.profile.loyalty_status}</h3>
+                        <h3 style={{ color: '#FCFAF6' }} className="text-2xl font-serif mb-6 !text-farm-cream">{t.profile.loyalty_status}</h3>
                         <div className="space-y-6">
                             <div className="flex justify-between items-center text-sm">
                                 <span className="text-farm-cream/60">{t.profile.tier}</span>


### PR DESCRIPTION
This PR applies a completely bulletproof fix to the Loyalty Status card heading contrast issue by using both a Tailwind important utility modifier (!text-farm-cream) and an inline CSS color style declaration (style={{ color: '#FCFAF6' }}). This bypasses Next.js global stylesheet ordering quirks where tag selectors globally style h1-h6 tags as text-farm-forest after components are loaded.