### PR TITLE
style: connect onTenantUpdate callback to refresh storefront and render specialty category badge

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -177,7 +177,11 @@ export default function TenantPage() {
             </nav>
 
             <div className="animate-in fade-in zoom-in-95 duration-1000">
-                {view === 'shop' || !isOwner ? <Shop tenant={tenant} /> : <Admin isOwner={isOwner} />}
+                {view === 'shop' || !isOwner ? (
+                    <Shop tenant={tenant} />
+                ) : (
+                    <Admin isOwner={isOwner} onTenantUpdate={(updated) => setTenant(updated)} />
+                )}
             </div>
 
             {showAuthModal && (

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -15,7 +15,7 @@ import { TrendingUp, Package, ShoppingCart, BookOpen, AlertCircle, Eye, EyeOff, 
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 
-export default function Admin({ isOwner = false }: { isOwner?: boolean }) {
+export default function Admin({ isOwner = false, onTenantUpdate }: { isOwner?: boolean; onTenantUpdate?: (tenant: any) => void }) {
     const { user } = useAuth();
     const { t, locale } = useLanguage();
     const { notify } = useNotify();
@@ -195,8 +195,11 @@ export default function Admin({ isOwner = false }: { isOwner?: boolean }) {
     const handleSaveAppearance = async () => {
         setLoading(true);
         try {
-            await api.put('tenants/appearance', { cover_url: coverUrl, description, category: farmCategory });
+            const res = await api.put('tenants/appearance', { cover_url: coverUrl, description, category: farmCategory });
             notify(t.admin.storefront.save_success, 'success');
+            if (onTenantUpdate) {
+                onTenantUpdate(res.data);
+            }
         } catch (err) {
             notify(t.admin.storefront.save_error, 'error');
         } finally {

--- a/src/components/Shop.tsx
+++ b/src/components/Shop.tsx
@@ -243,7 +243,12 @@ export default function Shop({ tenant }: ShopProps) {
 
             <div className="container mx-auto px-8 relative -mt-32 z-10">
                 <header className="text-center mb-24 glass-panel p-12 md:p-16 rounded-3xl shadow-xl max-w-5xl mx-auto border-farm-bark">
-                    <span className="premium-badge-gold mb-6 inline-block">{t.shop.producer_badge}</span>
+                    <div className="flex justify-center gap-2 mb-6">
+                        <span className="premium-badge-gold">{t.shop.producer_badge}</span>
+                        {tenant?.category?.Valid && tenant.category.String && (
+                            <span className="premium-badge bg-farm-gold text-white border-none">{tenant.category.String}</span>
+                        )}
+                    </div>
                     <h1 className="text-6xl md:text-8xl mb-6 font-serif">{t.shop.market_selection}</h1>
                     <div className="h-1 w-32 bg-gradient-to-r from-farm-forest to-farm-gold mx-auto mb-8 rounded-full" />
                     <p className="text-xl md:text-2xl text-farm-forest/70 max-w-2xl mx-auto font-serif italic">


### PR DESCRIPTION
This PR adds the onTenantUpdate prop to the Admin component and triggers it when saving storefront appearance. This reloads the parent tenant details state instantly upon saving the Farm Specialty/Category, description, or cover image. It also displays the Farm Specialty/Category badge next to the producer badge on the Shop header.