### PR TITLE
fix: resolve squished review page modal layout issue

### DIFF
--- a/src/components/Shop.tsx
+++ b/src/components/Shop.tsx
@@ -28,6 +28,7 @@ export default function Shop({ tenant }: ShopProps) {
     const [isCheckingOut, setIsCheckingOut] = useState(false);
     const [orderSuccess, setOrderSuccess] = useState(false);
     const [viewingProductId, setViewingProductId] = useState<string | null>(null);
+    const viewingProduct = products.find(p => p.id === viewingProductId);
     
     // Search & Filter States
     const [search, setSearch] = useState('');
@@ -344,31 +345,6 @@ export default function Shop({ tenant }: ShopProps) {
                                             {viewingProductId === product.id ? t.reviews.hide : t.reviews.view}
                                         </button>
                                     </div>
-                                    {viewingProductId === product.id && (
-                                        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 md:p-12 overflow-y-auto">
-                                            <div className="absolute inset-0 bg-farm-cream/95 backdrop-blur-md" onClick={() => setViewingProductId(null)} />
-                                            <div className="relative w-full max-w-6xl bg-white rounded-[3rem] shadow-2xl p-8 md:p-16 animate-in zoom-in-95 duration-500 overflow-y-auto max-h-full border border-farm-bark/10">
-                                                <button 
-                                                    onClick={() => setViewingProductId(null)}
-                                                    className="absolute top-8 right-8 text-farm-forest/40 hover:text-farm-forest"
-                                                >
-                                                    <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                                    </svg>
-                                                </button>
-                                                <div className="flex flex-col md:flex-row gap-12 items-center mb-16 border-b border-farm-bark/10 pb-16">
-                                                    <div className="w-48 h-48 rounded-full overflow-hidden shadow-xl border-4 border-white">
-                                                        <img src={product.image_url?.Valid ? product.image_url.String : `https://images.unsplash.com/photo-1542838132-92c53300491e?auto=format&fit=crop&q=80&w=400`} className="w-full h-full object-cover" />
-                                                    </div>
-                                                    <div className="text-center md:text-left">
-                                                        <h2 className="text-4xl md:text-6xl font-serif text-farm-forest mb-4">{product.name}</h2>
-                                                        <p className="text-xl text-farm-forest/60 font-serif italic max-w-xl">{product.description?.Valid ? product.description.String : t.shop.default_product_desc}</p>
-                                                    </div>
-                                                </div>
-                                                <ProductReviews productId={product.id} />
-                                            </div>
-                                        </div>
-                                    )}
                                 </div>
                             </div>
                         ))}
@@ -412,6 +388,31 @@ export default function Shop({ tenant }: ShopProps) {
             </div>
             {showAuthModal && (
                 <UserAuthModal onClose={() => setShowAuthModal(false)} onSuccess={() => setShowAuthModal(false)} />
+            )}
+            {viewingProduct && (
+                <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 md:p-12 overflow-y-auto animate-in fade-in duration-300">
+                    <div className="absolute inset-0 bg-farm-cream/95 backdrop-blur-md" onClick={() => setViewingProductId(null)} />
+                    <div className="relative w-full max-w-6xl bg-white rounded-[3rem] shadow-2xl p-8 md:p-16 animate-in zoom-in-95 duration-500 overflow-y-auto max-h-full border border-farm-bark/10">
+                        <button 
+                            onClick={() => setViewingProductId(null)}
+                            className="absolute top-8 right-8 text-farm-forest/40 hover:text-farm-forest"
+                        >
+                            <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                        <div className="flex flex-col md:flex-row gap-12 items-center mb-16 border-b border-farm-bark/10 pb-16">
+                            <div className="w-48 h-48 rounded-full overflow-hidden shadow-xl border-4 border-white">
+                                <img src={viewingProduct.image_url?.Valid ? viewingProduct.image_url.String : `https://images.unsplash.com/photo-1542838132-92c53300491e?auto=format&fit=crop&q=80&w=400`} className="w-full h-full object-cover" />
+                            </div>
+                            <div className="text-center md:text-left">
+                                <h2 className="text-4xl md:text-6xl font-serif text-farm-forest mb-4">{viewingProduct.name}</h2>
+                                <p className="text-xl text-farm-forest/60 font-serif italic max-w-xl">{viewingProduct.description?.Valid ? viewingProduct.description.String : t.shop.default_product_desc}</p>
+                            </div>
+                        </div>
+                        <ProductReviews productId={viewingProduct.id} />
+                    </div>
+                </div>
             )}
         </div>
     );


### PR DESCRIPTION
Extracts the product reviews detail modal out of the products map loop grid items to prevent it from inheriting parent translations and overflow constraints. This restores the full-width layout of the modal.