### PR TITLE
feat: implement Obsidian-like markdown editor and image uploads for journal

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -11,7 +11,7 @@ import {
     LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
     BarChart, Bar, Cell
 } from 'recharts';
-import { TrendingUp, Package, ShoppingCart, BookOpen, AlertCircle, Eye, EyeOff, Download } from 'lucide-react';
+import { TrendingUp, Package, ShoppingCart, BookOpen, AlertCircle, Eye, EyeOff, Download, Bold, Italic, Heading1, Heading2, Quote, Code, List, Link, Image as ImageIcon } from 'lucide-react';
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 
@@ -38,6 +38,49 @@ export default function Admin({ isOwner = false, onTenantUpdate }: { isOwner?: b
     const [blogTitle, setBlogTitle] = useState('');
     const [blogContent, setBlogContent] = useState('');
     const [editingBlogId, setEditingBlogId] = useState<string | null>(null);
+
+    const insertMarkdown = (prefix: string, suffix: string = '') => {
+        const textarea = document.getElementById('blog-editor-textarea') as HTMLTextAreaElement;
+        if (!textarea) return;
+
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const text = textarea.value;
+        const selected = text.substring(start, end);
+        const replacement = prefix + selected + suffix;
+
+        setBlogContent(text.substring(0, start) + replacement + text.substring(end));
+
+        // Refocus and restore selection
+        setTimeout(() => {
+            textarea.focus();
+            textarea.setSelectionRange(start + prefix.length, start + prefix.length + selected.length);
+        }, 0);
+    };
+
+    const handleInsertImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+
+        setLoading(true);
+        try {
+            const formData = new FormData();
+            formData.append('file', file);
+            const uploadRes = await api.post('upload', formData, {
+                headers: { 'Content-Type': 'multipart/form-data' }
+            });
+            let imageUrl = uploadRes.data.url;
+            if (!imageUrl.startsWith('http')) {
+                imageUrl = `${window.location.origin}${imageUrl}`;
+            }
+            insertMarkdown(`![${file.name}](${imageUrl})`);
+            notify(t.admin.storefront.logo_success || 'Image uploaded!', 'success');
+        } catch {
+            notify(t.admin.storefront.logo_error || 'Error uploading image.', 'error');
+        } finally {
+            setLoading(false);
+        }
+    };
 
     const [coverUrl, setCoverUrl] = useState('');
     const [description, setDescription] = useState('');
@@ -586,7 +629,33 @@ export default function Admin({ isOwner = false, onTenantUpdate }: { isOwner?: b
                             <h2 className="text-2xl font-serif mb-6 text-farm-forest">{editingBlogId ? t.admin.journal.edit_entry : t.admin.journal.new_entry}</h2>
                             <form onSubmit={handleCreateOrUpdateBlog} className="space-y-6">
                                 <input className="premium-input" placeholder={t.admin.journal.title} value={blogTitle} onChange={e => setBlogTitle(e.target.value)} required />
-                                <textarea className="premium-input h-64" placeholder={t.admin.journal.content} value={blogContent} onChange={e => setBlogContent(e.target.value)} required />
+                                <div className="space-y-0">
+                                    <div className="flex flex-wrap items-center gap-1 bg-farm-parchment/50 border border-farm-bark/80 p-2.5 rounded-t-xl border-b-0">
+                                        <button type="button" onClick={() => insertMarkdown('**', '**')} className="p-2 hover:bg-farm-bark/30 text-farm-forest rounded-lg transition-colors" title="Bold"><Bold size={16} /></button>
+                                        <button type="button" onClick={() => insertMarkdown('*', '*')} className="p-2 hover:bg-farm-bark/30 text-farm-forest rounded-lg transition-colors" title="Italic"><Italic size={16} /></button>
+                                        <div className="w-px h-6 bg-farm-bark/60 mx-1" />
+                                        <button type="button" onClick={() => insertMarkdown('# ')} className="p-2 hover:bg-farm-bark/30 text-farm-forest rounded-lg transition-colors" title="Heading 1"><Heading1 size={16} /></button>
+                                        <button type="button" onClick={() => insertMarkdown('## ')} className="p-2 hover:bg-farm-bark/30 text-farm-forest rounded-lg transition-colors" title="Heading 2"><Heading2 size={16} /></button>
+                                        <div className="w-px h-6 bg-farm-bark/60 mx-1" />
+                                        <button type="button" onClick={() => insertMarkdown('> ')} className="p-2 hover:bg-farm-bark/30 text-farm-forest rounded-lg transition-colors" title="Blockquote"><Quote size={16} /></button>
+                                        <button type="button" onClick={() => insertMarkdown('`', '`')} className="p-2 hover:bg-farm-bark/30 text-farm-forest rounded-lg transition-colors" title="Code"><Code size={16} /></button>
+                                        <button type="button" onClick={() => insertMarkdown('- ')} className="p-2 hover:bg-farm-bark/30 text-farm-forest rounded-lg transition-colors" title="List"><List size={16} /></button>
+                                        <button type="button" onClick={() => insertMarkdown('[', '](url)')} className="p-2 hover:bg-farm-bark/30 text-farm-forest rounded-lg transition-colors" title="Link"><Link size={16} /></button>
+                                        <div className="w-px h-6 bg-farm-bark/60 mx-1" />
+                                        <label className="p-2 hover:bg-farm-bark/30 text-farm-forest rounded-lg transition-colors cursor-pointer" title="Upload Image">
+                                            <ImageIcon size={16} className="inline" />
+                                            <input type="file" accept="image/*" onChange={handleInsertImage} className="hidden" />
+                                        </label>
+                                    </div>
+                                    <textarea 
+                                        id="blog-editor-textarea"
+                                        className="premium-input !rounded-t-none h-64 border-t-0" 
+                                        placeholder={t.admin.journal.content} 
+                                        value={blogContent} 
+                                        onChange={e => setBlogContent(e.target.value)} 
+                                        required 
+                                    />
+                                </div>
                                 <div className="flex gap-2">
                                     <button disabled={loading} className="premium-btn flex-1">{editingBlogId ? t.common.save : t.common.confirm}</button>
                                     {editingBlogId && <button type="button" onClick={() => setEditingBlogId(null)} className="premium-btn-outline">{t.common.cancel}</button>}

--- a/src/components/Shop.tsx
+++ b/src/components/Shop.tsx
@@ -374,7 +374,22 @@ export default function Shop({ tenant }: ShopProps) {
                                     <div className="w-full max-w-3xl glass-panel p-10 md:p-14 rounded-3xl text-left relative overflow-hidden transition-all duration-500 group-hover:shadow-xl group-hover:border-farm-pine/20">
                                         <div className="absolute top-0 left-0 w-2 h-full bg-farm-gold/80" />
                                         <div className="prose prose-slate prose-lg max-w-none text-farm-forest/80 font-sans leading-relaxed font-light mb-12">
-                                            <ReactMarkdown>{blog.content_md}</ReactMarkdown>
+                                            <ReactMarkdown
+                                                components={{
+                                                    img: (props) => {
+                                                        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                                                        const { node, ...rest } = props;
+                                                        return (
+                                                            <img 
+                                                                {...rest} 
+                                                                className="rounded-2xl max-w-full h-auto my-6 shadow-md border border-farm-bark/10 transition-transform hover:scale-[1.01]" 
+                                                            />
+                                                        );
+                                                    }
+                                                }}
+                                            >
+                                                {blog.content_md}
+                                            </ReactMarkdown>
                                         </div>
                                         <div className="flex justify-center">
                                             <button className="premium-btn-outline !px-12">{t.shop.read_more}</button>


### PR DESCRIPTION
Adds an Obsidian-like markdown formatting toolbar above the blog textarea in Admin.tsx, integrates direct local image uploads via the /upload endpoint, and styles markdown images on the storefront in Shop.tsx.