### PR TITLE
fix: restore markdown elements styling and implement blog expand/collapse button

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,3 +120,101 @@ input, textarea {
 .animate-pulse-soft {
   animation: pulse-soft 3s ease-in-out infinite;
 }
+
+/* Prose Markdown styling */
+.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
+  font-family: var(--font-serif);
+  color: var(--color-farm-forest);
+  font-weight: 700;
+  line-height: 1.25;
+}
+.prose h1 {
+  font-size: 2.25rem;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+.prose h2 {
+  font-size: 1.875rem;
+  margin-top: 1.75rem;
+  margin-bottom: 0.875rem;
+  border-bottom: 1px solid var(--color-farm-bark);
+  padding-bottom: 0.5rem;
+}
+.prose h3 {
+  font-size: 1.5rem;
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+.prose h4 {
+  font-size: 1.25rem;
+  margin-top: 1.25rem;
+  margin-bottom: 0.6rem;
+}
+.prose p {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  line-height: 1.75;
+}
+.prose strong, .prose b {
+  font-weight: 700;
+  color: var(--color-farm-forest);
+}
+.prose em, .prose i {
+  font-style: italic;
+}
+.prose ul {
+  list-style-type: disc;
+  padding-left: 1.75rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+.prose ol {
+  list-style-type: decimal;
+  padding-left: 1.75rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+.prose li {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  display: list-item;
+}
+.prose blockquote {
+  border-left: 4px solid var(--color-farm-gold);
+  padding-left: 1.25rem;
+  font-style: italic;
+  margin: 1.5rem 0;
+  color: var(--color-farm-forest);
+  opacity: 0.85;
+}
+.prose code {
+  background-color: var(--color-farm-parchment);
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.375rem;
+  font-family: monospace;
+  font-size: 0.875em;
+  color: var(--color-farm-pine);
+}
+.prose pre {
+  background-color: var(--color-farm-forest);
+  color: var(--color-farm-cream);
+  padding: 1.25rem;
+  border-radius: 0.75rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+.prose pre code {
+  background-color: transparent;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+  font-size: inherit;
+}
+.prose a {
+  color: var(--color-farm-pine);
+  text-decoration: underline;
+  font-weight: 500;
+}
+.prose a:hover {
+  color: var(--color-farm-gold);
+}

--- a/src/components/Shop.tsx
+++ b/src/components/Shop.tsx
@@ -17,12 +17,13 @@ interface ShopProps {
 
 export default function Shop({ tenant }: ShopProps) {
     const { user } = useAuth();
-    const { t, locale } = useLanguage();
+    const { t } = useLanguage();
     const { notify } = useNotify();
     const [products, setProducts] = useState<Product[]>([]);
     const [blogs, setBlogs] = useState<Blog[]>([]);
     const [loading, setLoading] = useState(true);
     const [basket, setBasket] = useState<BasketItem[]>([]);
+    const [expandedBlogs, setExpandedBlogs] = useState<Record<string, boolean>>({});
     const [isBasketOpen, setIsBasketOpen] = useState(false);
     const [showAuthModal, setShowAuthModal] = useState(false);
     const [isCheckingOut, setIsCheckingOut] = useState(false);
@@ -67,7 +68,7 @@ export default function Shop({ tenant }: ShopProps) {
                 console.error("Failed to parse basket", e);
             }
         }
-    }, [tenant?.slug, search, category]);
+    }, [tenant?.slug, search, category, user]);
 
     useEffect(() => {
         if (tenant?.slug) {
@@ -125,9 +126,9 @@ export default function Shop({ tenant }: ShopProps) {
             setOrderSuccess(true);
             setIsBasketOpen(false);
             setTimeout(() => setOrderSuccess(false), 5000);
-        } catch (err: any) {
+        } catch (err: unknown) {
             console.error("Checkout failed", err);
-            const errMsg = err.response?.data?.error || t.shop.checkout_failed;
+            const errMsg = (err as { response?: { data?: { error?: string } } }).response?.data?.error || t.shop.checkout_failed;
             notify(errMsg, 'error');
         } finally {
             setIsCheckingOut(false);
@@ -174,7 +175,7 @@ export default function Shop({ tenant }: ShopProps) {
                         <div className="flex-1 overflow-y-auto p-8 space-y-6">
                             {basket.length === 0 ? (
                                 <div className="text-center py-20 text-farm-forest/40 italic font-serif text-xl">
-                                    "{t.shop.empty_basket}"
+                                    &ldquo;{t.shop.empty_basket}&rdquo;
                                 </div>
                             ) : (
                                 basket.map((item) => (
@@ -302,7 +303,7 @@ export default function Shop({ tenant }: ShopProps) {
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
                         {products.length === 0 ? (
                             <div className="col-span-full py-32 text-center glass-panel rounded-3xl text-farm-forest/40 italic font-serif text-2xl border-dashed">
-                                "{t.shop.no_products}"
+                                &ldquo;{t.shop.no_products}&rdquo;
                             </div>
                         ) : products.map((product) => (
                             <div key={product.id} className="premium-card group flex flex-col h-full bg-white relative">
@@ -365,39 +366,72 @@ export default function Shop({ tenant }: ShopProps) {
                             <div className="text-center text-farm-forest/30 italic font-serif text-xl bg-white p-16 rounded-3xl border border-farm-bark/50">
                                 {t.shop.no_stories}
                             </div>
-                        ) : blogs.map((blog) => (
-                            <article key={blog.id} className="group cursor-pointer">
-                                <div className="flex flex-col items-center text-center">
-                                    <span className="text-[10px] font-bold uppercase tracking-[0.4em] text-farm-gold mb-6 border-b border-farm-gold pb-2">{formatLongDate(blog.published_at)}</span>
-                                    <h3 className="text-5xl md:text-6xl mb-10 leading-[1.1] max-w-3xl font-serif group-hover:text-farm-pine transition-colors">{blog.title}</h3>
-                                    
-                                    <div className="w-full max-w-3xl glass-panel p-10 md:p-14 rounded-3xl text-left relative overflow-hidden transition-all duration-500 group-hover:shadow-xl group-hover:border-farm-pine/20">
-                                        <div className="absolute top-0 left-0 w-2 h-full bg-farm-gold/80" />
-                                        <div className="prose prose-slate prose-lg max-w-none text-farm-forest/80 font-sans leading-relaxed font-light mb-12">
-                                            <ReactMarkdown
-                                                components={{
-                                                    img: (props) => {
-                                                        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                                                        const { node, ...rest } = props;
-                                                        return (
-                                                            <img 
-                                                                {...rest} 
-                                                                className="rounded-2xl max-w-full h-auto my-6 shadow-md border border-farm-bark/10 transition-transform hover:scale-[1.01]" 
-                                                            />
-                                                        );
-                                                    }
-                                                }}
-                                            >
-                                                {blog.content_md}
-                                            </ReactMarkdown>
-                                        </div>
-                                        <div className="flex justify-center">
-                                            <button className="premium-btn-outline !px-12">{t.shop.read_more}</button>
+                        ) : blogs.map((blog) => {
+                            const isExpanded = !!expandedBlogs[blog.id];
+                            return (
+                                <article key={blog.id} className="group">
+                                    <div className="flex flex-col items-center text-center">
+                                        <span className="text-[10px] font-bold uppercase tracking-[0.4em] text-farm-gold mb-6 border-b border-farm-gold pb-2">{formatLongDate(blog.published_at)}</span>
+                                        <h3 
+                                            onClick={() => {
+                                                if (!isExpanded) {
+                                                    setExpandedBlogs(prev => ({ ...prev, [blog.id]: true }));
+                                                }
+                                            }}
+                                            className={`text-5xl md:text-6xl mb-10 leading-[1.1] max-w-3xl font-serif group-hover:text-farm-pine transition-colors ${!isExpanded ? 'cursor-pointer' : ''}`}
+                                        >
+                                            {blog.title}
+                                        </h3>
+                                        
+                                        <div 
+                                            onClick={() => {
+                                                if (!isExpanded) {
+                                                    setExpandedBlogs(prev => ({ ...prev, [blog.id]: true }));
+                                                }
+                                            }}
+                                            className={`w-full max-w-3xl glass-panel p-10 md:p-14 rounded-3xl text-left relative overflow-hidden transition-all duration-500 group-hover:shadow-xl group-hover:border-farm-pine/20 ${!isExpanded ? 'cursor-pointer' : ''}`}
+                                        >
+                                            <div className="absolute top-0 left-0 w-2 h-full bg-farm-gold/80" />
+                                            <div className={`relative overflow-hidden transition-all duration-500 ${isExpanded ? 'max-h-none mb-12' : 'max-h-48'}`}>
+                                                <div className="prose prose-slate prose-lg max-w-none text-farm-forest/80 font-sans leading-relaxed font-light mb-12">
+                                                    <ReactMarkdown
+                                                        components={{
+                                                            img: (props) => {
+                                                                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                                                                const { node, ...rest } = props;
+                                                                return (
+                                                                    <img 
+                                                                        {...rest} 
+                                                                        className="rounded-2xl max-w-full h-auto my-6 shadow-md border border-farm-bark/10 transition-transform hover:scale-[1.01]" 
+                                                                        alt={rest.alt || "Blog image"}
+                                                                    />
+                                                                );
+                                                            }
+                                                        }}
+                                                    >
+                                                        {blog.content_md}
+                                                    </ReactMarkdown>
+                                                </div>
+                                                {!isExpanded && (
+                                                    <div className="absolute bottom-0 left-0 w-full h-24 bg-gradient-to-t from-white via-white/80 to-transparent pointer-events-none" />
+                                                )}
+                                            </div>
+                                            <div className="flex justify-center">
+                                                <button 
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        setExpandedBlogs(prev => ({ ...prev, [blog.id]: !isExpanded }));
+                                                    }}
+                                                    className="premium-btn-outline !px-12"
+                                                >
+                                                    {isExpanded ? t.shop.read_less : t.shop.read_more}
+                                                </button>
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                            </article>
-                        ))}
+                                </article>
+                            );
+                        })}
                     </div>
                 </section>
             </div>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -38,6 +38,7 @@
     "journal_title": "Hof-Journal",
     "journal_subtitle": "Chroniken unserer täglichen Arbeit, Gemeinschaftsanlässe und saisonalen Übergänge.",
     "read_more": "Vollständigen Eintrag lesen",
+    "read_less": "Eintrag minimieren",
     "no_stories": "Noch keine Geschichten geteilt.",
     "showing": "Zeige",
     "items": "Artikel",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,6 +38,7 @@
     "journal_title": "Farm Journal",
     "journal_subtitle": "Chronicles of our daily labor, community events, and seasonal transitions.",
     "read_more": "Read Full Entry",
+    "read_less": "Collapse Entry",
     "no_stories": "No stories shared just yet.",
     "showing": "Showing",
     "items": "Items",


### PR DESCRIPTION
Restores markdown formatting (headers, lists, bold text) and implements expand/collapse toggles for blog entries in the storefront journal.