### PR TITLE
fix: make Shop page data fetching resilient with Promise.allSettled

### DIFF
--- a/src/components/Shop.tsx
+++ b/src/components/Shop.tsx
@@ -40,14 +40,26 @@ export default function Shop({ tenant }: ShopProps) {
     useEffect(() => {
         const fetchData = async () => {
             try {
-                const [productsRes, blogsRes, catsRes] = await Promise.all([
+                const [productsRes, blogsRes, catsRes] = await Promise.allSettled([
                     api.get('products', { params: { search, category } }),
                     api.get('blogs'),
                     api.get('categories')
                 ]);
-                setProducts(productsRes.data || []);
-                setBlogs(blogsRes.data || []);
-                setCategories(catsRes.data || []);
+                if (productsRes.status === 'fulfilled') {
+                    setProducts(productsRes.value.data || []);
+                } else {
+                    console.error('Failed to fetch products', productsRes.reason);
+                }
+                if (blogsRes.status === 'fulfilled') {
+                    setBlogs(blogsRes.value.data || []);
+                } else {
+                    console.error('Failed to fetch blogs', blogsRes.reason);
+                }
+                if (catsRes.status === 'fulfilled') {
+                    setCategories(catsRes.value.data || []);
+                } else {
+                    console.error('Failed to fetch categories', catsRes.reason);
+                }
             } catch (err) {
                 console.error('Failed to fetch data', err);
             } finally {


### PR DESCRIPTION
Uses Promise.allSettled for data fetching so that failing queries do not block other storefront data from loading.