### PR TITLE
fix: resolve review modal overlapping and make reviews list independently scrollable

### DIFF
--- a/src/components/ProductReviews.tsx
+++ b/src/components/ProductReviews.tsx
@@ -73,23 +73,23 @@ export default function ProductReviews({ productId }: Props) {
     };
 
     return (
-        <section className="mt-20 border-t border-farm-bark/10 pt-16">
-            <div className="flex flex-col md:flex-row justify-between items-start gap-12">
-                <div className="w-full md:w-1/3">
-                    <h2 className="text-3xl font-serif text-farm-forest mb-6">{t.reviews.title}</h2>
-                    <div className="glass-panel p-8 rounded-3xl text-center mb-8">
-                        <p className="text-5xl font-serif text-farm-pine mb-2">{stats.avg_rating.toFixed(1)}</p>
+        <section className="mt-4 pt-4 border-t border-farm-bark/10 flex-1 min-h-0 flex flex-col overflow-hidden">
+            <div className="flex flex-col md:flex-row justify-between items-stretch gap-12 flex-1 min-h-0 overflow-hidden">
+                <div className="w-full md:w-1/3 flex flex-col gap-6 overflow-y-auto pr-2 max-h-full flex-shrink-0 pb-6">
+                    <h2 className="text-2xl font-serif text-farm-forest mb-2">{t.reviews.title}</h2>
+                    <div className="glass-panel p-6 rounded-3xl text-center">
+                        <p className="text-4xl font-serif text-farm-pine mb-1">{stats.avg_rating.toFixed(1)}</p>
                         <div className="flex justify-center gap-1 mb-2">
                             {[1, 2, 3, 4, 5].map(s => (
-                                <Star key={s} size={20} className={s <= Math.round(stats.avg_rating) ? 'fill-farm-gold text-farm-gold' : 'text-farm-bark/30'} />
+                                <Star key={s} size={16} className={s <= Math.round(stats.avg_rating) ? 'fill-farm-gold text-farm-gold' : 'text-farm-bark/30'} />
                             ))}
                         </div>
-                        <p className="text-xs font-bold uppercase tracking-widest text-farm-forest/40">{t.reviews.based_on.replace('{count}', stats.review_count.toString())}</p>
+                        <p className="text-[10px] font-bold uppercase tracking-widest text-farm-forest/40">{t.reviews.based_on.replace('{count}', stats.review_count.toString())}</p>
                     </div>
 
                     {user && (
-                        <div className="glass-panel p-8 rounded-3xl">
-                            <h3 className="font-serif text-lg mb-6">{t.reviews.share_exp}</h3>
+                        <div className="glass-panel p-6 rounded-3xl">
+                            <h3 className="font-serif text-base mb-4">{t.reviews.share_exp}</h3>
                             <form onSubmit={handleSubmitReview} className="space-y-4">
                                 <div className="flex gap-2">
                                     {[1, 2, 3, 4, 5].map(s => (
@@ -99,19 +99,19 @@ export default function ProductReviews({ productId }: Props) {
                                             onClick={() => setRating(s)}
                                             className="transition-transform active:scale-90"
                                         >
-                                            <Star size={24} className={s <= rating ? 'fill-farm-gold text-farm-gold' : 'text-farm-bark/30'} />
+                                            <Star size={20} className={s <= rating ? 'fill-farm-gold text-farm-gold' : 'text-farm-bark/30'} />
                                         </button>
                                     ))}
                                 </div>
                                 <textarea 
-                                    className="premium-input h-32 !text-sm" 
+                                    className="premium-input h-24 !text-xs !p-3" 
                                     placeholder={t.reviews.placeholder}
                                     value={comment}
                                     onChange={e => setComment(e.target.value)}
                                     required
                                 />
-                                <button disabled={loading} className="premium-btn w-full flex items-center justify-center gap-2">
-                                    <Send size={16} />
+                                <button disabled={loading} className="premium-btn w-full flex items-center justify-center gap-2 py-2 text-[10px]">
+                                    <Send size={12} />
                                     {t.reviews.submit}
                                 </button>
                             </form>
@@ -119,30 +119,30 @@ export default function ProductReviews({ productId }: Props) {
                     )}
                 </div>
 
-                <div className="w-full md:w-2/3 space-y-6">
+                <div className="w-full md:w-2/3 space-y-6 overflow-y-auto pr-4 max-h-full pb-6">
                     {reviews.length > 0 ? (
                         reviews.map(review => (
-                            <div key={review.id} className="bg-white/50 p-8 rounded-3xl border border-farm-bark/10 hover:border-farm-gold/20 transition-all">
-                                <div className="flex justify-between items-start mb-4">
+                            <div key={review.id} className="bg-white/50 p-6 rounded-3xl border border-farm-bark/10 hover:border-farm-gold/20 transition-all">
+                                <div className="flex justify-between items-start mb-3">
                                     <div>
                                         <p className="font-bold text-farm-forest text-sm">{review.user_email}</p>
                                         <div className="flex gap-0.5 mt-1">
                                             {[1, 2, 3, 4, 5].map(s => (
-                                                <Star key={s} size={12} className={s <= review.rating ? 'fill-farm-gold text-farm-gold' : 'text-farm-bark/30'} />
+                                                <Star key={s} size={10} className={s <= review.rating ? 'fill-farm-gold text-farm-gold' : 'text-farm-bark/30'} />
                                             ))}
                                         </div>
                                     </div>
-                                    <p className="text-[10px] text-farm-forest/40 font-bold uppercase tracking-widest">{formatLongDate(review.created_at)}</p>
+                                    <p className="text-[9px] text-farm-forest/40 font-bold uppercase tracking-widest">{formatLongDate(review.created_at)}</p>
                                 </div>
-                                <p className="text-farm-forest/70 text-sm leading-relaxed italic">
+                                <p className="text-farm-forest/70 text-xs leading-relaxed italic">
                                     &quot;{review.comment.Valid ? review.comment.String : t.reviews.no_comment}&quot;
                                 </p>
                             </div>
                         ))
                     ) : (
-                        <div className="py-20 text-center glass-panel rounded-3xl border-dashed">
-                            <MessageSquare className="mx-auto text-farm-bark/20 mb-4" size={48} />
-                            <p className="text-xl font-serif italic text-farm-forest/30">{t.reviews.no_reviews}</p>
+                        <div className="py-16 text-center glass-panel rounded-3xl border-dashed">
+                            <MessageSquare className="mx-auto text-farm-bark/20 mb-3" size={36} />
+                            <p className="text-lg font-serif italic text-farm-forest/30">{t.reviews.no_reviews}</p>
                         </div>
                     )}
                 </div>

--- a/src/components/Shop.tsx
+++ b/src/components/Shop.tsx
@@ -451,24 +451,24 @@ export default function Shop({ tenant }: ShopProps) {
                 <UserAuthModal onClose={() => setShowAuthModal(false)} onSuccess={() => setShowAuthModal(false)} />
             )}
             {viewingProduct && (
-                <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 md:p-12 overflow-y-auto animate-in fade-in duration-300">
+                <div className="fixed inset-0 z-[1100] flex items-center justify-center p-4 md:p-12 overflow-hidden animate-in fade-in duration-300">
                     <div className="absolute inset-0 bg-farm-cream/95 backdrop-blur-md" onClick={() => setViewingProductId(null)} />
-                    <div className="relative w-full max-w-6xl bg-white rounded-[3rem] shadow-2xl p-8 md:p-16 animate-in zoom-in-95 duration-500 overflow-y-auto max-h-full border border-farm-bark/10">
+                    <div className="relative w-full max-w-6xl bg-white rounded-[3rem] shadow-2xl p-8 md:p-16 animate-in zoom-in-95 duration-500 max-h-[90vh] flex flex-col border border-farm-bark/10 overflow-hidden">
                         <button 
                             onClick={() => setViewingProductId(null)}
-                            className="absolute top-8 right-8 text-farm-forest/40 hover:text-farm-forest"
+                            className="absolute top-8 right-8 text-farm-forest/40 hover:text-farm-forest z-10"
                         >
                             <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                             </svg>
                         </button>
-                        <div className="flex flex-col md:flex-row gap-12 items-center mb-16 border-b border-farm-bark/10 pb-16">
-                            <div className="w-48 h-48 rounded-full overflow-hidden shadow-xl border-4 border-white">
+                        <div className="flex flex-col md:flex-row gap-12 items-center mb-8 border-b border-farm-bark/10 pb-8 flex-shrink-0">
+                            <div className="w-32 h-32 md:w-40 md:h-40 rounded-full overflow-hidden shadow-xl border-4 border-white">
                                 <img src={viewingProduct.image_url?.Valid ? viewingProduct.image_url.String : `https://images.unsplash.com/photo-1542838132-92c53300491e?auto=format&fit=crop&q=80&w=400`} className="w-full h-full object-cover" />
                             </div>
                             <div className="text-center md:text-left">
-                                <h2 className="text-4xl md:text-6xl font-serif text-farm-forest mb-4">{viewingProduct.name}</h2>
-                                <p className="text-xl text-farm-forest/60 font-serif italic max-w-xl">{viewingProduct.description?.Valid ? viewingProduct.description.String : t.shop.default_product_desc}</p>
+                                <h2 className="text-3xl md:text-5xl font-serif text-farm-forest mb-2">{viewingProduct.name}</h2>
+                                <p className="text-lg text-farm-forest/60 font-serif italic max-w-xl line-clamp-2">{viewingProduct.description?.Valid ? viewingProduct.description.String : t.shop.default_product_desc}</p>
                             </div>
                         </div>
                         <ProductReviews productId={viewingProduct.id} />


### PR DESCRIPTION
Sets z-index of reviews modal higher than storefront header navigation, and adds independent scroll containers inside the modal to prevent vertical clipping.