### PR TITLE
Redirect checkout directly to online payment gateway

### DIFF
--- a/src/components/Shop.tsx
+++ b/src/components/Shop.tsx
@@ -173,7 +173,11 @@ export default function Shop({ tenant }: ShopProps) {
 
             setBasket([]);
             setIsBasketOpen(false);
-            router.push(`/orders/${res.data.order.id}`);
+            if (res.data.redirect_url) {
+                window.location.href = res.data.redirect_url;
+            } else {
+                router.push(`/orders/${res.data.order.id}`);
+            }
         } catch (err: unknown) {
             console.error("Checkout failed", err);
             const errMsg = (err as { response?: { data?: { error?: string } } }).response?.data?.error || t.shop.checkout_failed;


### PR DESCRIPTION
This PR updates the checkout flow so that users are redirected directly to Payrexx on checkout, and return back to the order page only after completion/failure.